### PR TITLE
ENYO-2595: Nightly build result of ARES is cracked

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
 	},
 	"files": [
 		"LICENSE-2.0.txt",
-		"README.md"
+		"README.md",
+		"ares-generator.js",
+		"copyFile.js",
+		"scripts"
 	]
 }


### PR DESCRIPTION
ares-generator package.json was not sufficient.
added `ares-generator.js,  copyFile.js, scripts` into file property.

Enyo-DCO-1.1-Signed-off-by: Junil Kim logyourself@gmail.com
