### PR TITLE
ENYO-2063: adapt to Node.js 0.10

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "node_modules/unzip"]
+	path = node_modules/unzip
+	url = ../../enyojs/node-unzip.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "node_modules/unzip"]
-	path = node_modules/unzip
-	url = ../../enyojs/node-unzip.git

--- a/ares-generator.js
+++ b/ares-generator.js
@@ -197,6 +197,10 @@ var shell = require("shelljs"),
 					prefix: 'com.enyojs.ares.generator',
 					suffix: ".d"
 				}, (function(err, tmpDir) {
+					if (err) {
+						next(err);
+						return;
+					}
 					// all those dirs will be
 					// cleaned when `tmpDir` will
 					// go out of scope.

--- a/ares-generator.js
+++ b/ares-generator.js
@@ -240,9 +240,7 @@ var shell = require("shelljs"),
 				url: url,
 				proxy: this.config.proxyUrl
 			}).pipe(
-				fs.createWriteStream(context.archive)
-					.on('error', next)
-					.on('close', next)
+				fs.createWriteStream(context.archive).on('close', next)
 			);
 		} catch(err) {
 			next(err);
@@ -250,32 +248,11 @@ var shell = require("shelljs"),
 	}
 
 	function _unzipFile(context, next) {
-		/*
-		 * WARNING:
-		 * - node-unzip <= 0.1.4 works with Node.js 0.8 only
-		 * - `node-unzip/max-call-stack-exceeded-wip@HEAD` works with Node.js 0.10 only
-		 */
-		var extractor;
 		log.silly("Generator#_unzipFile()", context.archive, "=>", context.workDir);
 		try {
-			if (false /*NODE_V_0_8*/) {
-				log.silly("Generator#_unzipFile()", "Using Node.js 0.8 plumbing sequence");
-				extractor = unzip.Extract({ path: context.workDir });
-				fs.createReadStream(context.archive).pipe(extractor);
-				extractor.on('close', next); // works up to node-unzip@0.1.4
-			} else {
-				log.silly("Generator#_unzipFile()", "Using Node.js 0.10 plumbing sequence");
-				/*
-				fs.createReadStream(context.archive).pipe(
-					unzip.Extract({ path: context.workDir })
-						.on('error', next)
-						.on('finish', next)
-				);
-				 */
-				extractor = unzip.Extract({ path: context.workDir });
-				extractor.on('close', next);
-				fs.createReadStream(context.archive).pipe(extractor);
-			}
+			var extractor = unzip.Extract({ path: context.workDir });
+			extractor.on('close', next);
+			fs.createReadStream(context.archive).pipe(extractor);
 		} catch(err) {
 			next(err);
 		}

--- a/ares-generator.js
+++ b/ares-generator.js
@@ -16,6 +16,8 @@ var shell = require("shelljs"),
 
 	var generator = {};
 
+	var NODE_V_0_8 = !!process.version.match('^v0.8');
+
 	if (typeof module !== 'undefined' && module.exports) {
 		module.exports = generator;
 	}
@@ -140,6 +142,13 @@ var shell = require("shelljs"),
 			 */
 			log.info("generate()", "substitutions:", substitutions);
 
+			// Do not overwrite the target directory (as a
+			// whole) in case it already exists.
+			if (!options.overwrite && fs.existsSync(destination)) {
+				next(new Error("'" + destination + "' already exists"));
+				return;
+			}
+
 			async.series([
 				async.forEachSeries.bind(generator, sources, _processSource.bind(generator)),
 				_substitute.bind(generator, substitutions, destination)
@@ -181,109 +190,122 @@ var shell = require("shelljs"),
 
 			function _processZipFile(item, next) {
 				log.info("generate#_processZipFile()", "Processing " + item.url);
-				
-				temp.mkdir({prefix: 'com.hp.ares.gen.processZipFile'}, (function(err, zipDir) {
+				var context = {
+					item: item
+				};
+				temp.mkdir({
+					prefix: 'com.enyojs.ares.generator',
+					suffix: ".d"
+				}, (function(err, tmpDir) {
+					// all those dirs will be
+					// cleaned when `tmpDir` will
+					// go out of scope.
+					context.archive = path.join(tmpDir, "archive");
+					context.workDir = path.join(tmpDir, "work");
+					context.destDir = destination;
+
 					async.series([
-						_unzipFile.bind(generator, item, generator.config, zipDir),
-						_removeExcludedFiles.bind(generator, item, zipDir),
-						_prefix.bind(generator, item, zipDir, destination, options)
+						_fetchFile.bind(generator, context),
+						fs.mkdir.bind(this, context.workDir),
+						_unzipFile.bind(generator, context),
+						_removeExcludedFiles.bind(generator, context),
+						_prefix.bind(generator, context),
+						rimraf.bind(this, tmpDir) // otherwise cleaned-up at process exit
 					], next);
 				}));
 			}
 		}
 	};
 
-	function _unzipFile(item, config, destination, next) {
+	// This method works both on node-0.8 & node-0.10 (do not
+	// laugh, this is not easy to achieve...)
+	function _fetchFile(context, next) {
+		log.silly("Generator#_fetchFile()");
 		try {
-			var source = item.url;
+			var url = context.item.url;
 
-			if ((source.substr(0, 4) !== 'http') && ( ! fs.existsSync(source))) {
-				if (item.alternateUrl) {
-					source = item.alternateUrl;
-				} else {
-					next(new Error("File '" + source + "' does not exists"));
-					return;
-				}
+			if (fs.existsSync(url)) {
+				context.archive = url;
+				next();
+				return;
 			}
 
-			log.verbose("_unzipFile()", "Unzipping " + source + " to " + destination);
-
-			// Create an extractor to unzip the template
-			var extractor = unzip.Extract({ path: destination });
-			extractor.on('error', next);
-
-			// Building the zipStream either from a file or an http request
-			var zipStream;
-			if (source.substr(0, 4) === 'http') {
-				var reqOptions = {
-					url: source,
-					proxy: config.proxyUrl
-				};
-				log.http("GET " + source);
-				zipStream = request(reqOptions);
-			} else {
-				zipStream = fs.createReadStream(source);
+			if (url.substr(0, 4) !== 'http') {
+				next(new Error("Source '" + url + "' does not exists"));
+				return;
 			}
 
-			// Pipe the zipped content to the extractor to actually perform the unzip
-			zipStream.pipe(extractor);
-
-			// Wait for the end of the extraction
-			extractor.on('close', next);
+			log.http("Generator#_fetchFile()", "GET", url, "=>", context.archive);
+			request({
+				url: url,
+				proxy: this.config.proxyUrl
+			}).pipe(
+				fs.createWriteStream(context.archive)
+					.on('error', next)
+					.on('close', next)
+			);
 		} catch(err) {
 			next(err);
 		}
 	}
 
-	function _removeExcludedFiles(item, destination, next) {
-		if (item.excluded) {            // TODO: move to asynchronous processing
-			log.verbose("_removeExcludedFiles()", "removing excluded files");
-			shell.ls('-R', destination).forEach(function(file) {
-				item.excluded.forEach(function(pattern) {
-					var regexp = new RegExp(pattern);
-					if (regexp.test(file)) {
-						log.verbose("_removeExcludedFiles()", "removing: " + file);
-						var filename = path.join(destination, file);
-						shell.rm('-rf', filename);
-					}
-				});
-			});
+	function _unzipFile(context, next) {
+		/*
+		 * WARNING:
+		 * - node-unzip <= 0.1.4 works with Node.js 0.8 only
+		 * - `node-unzip/max-call-stack-exceeded-wip@HEAD` works with Node.js 0.10 only
+		 */
+		var extractor;
+		log.silly("Generator#_unzipFile()", context.archive, "=>", context.workDir);
+		try {
+			if (false /*NODE_V_0_8*/) {
+				log.silly("Generator#_unzipFile()", "Using Node.js 0.8 plumbing sequence");
+				extractor = unzip.Extract({ path: context.workDir });
+				fs.createReadStream(context.archive).pipe(extractor);
+				extractor.on('close', next); // works up to node-unzip@0.1.4
+			} else {
+				log.silly("Generator#_unzipFile()", "Using Node.js 0.10 plumbing sequence");
+				/*
+				fs.createReadStream(context.archive).pipe(
+					unzip.Extract({ path: context.workDir })
+						.on('error', next)
+						.on('finish', next)
+				);
+				 */
+				extractor = unzip.Extract({ path: context.workDir });
+				extractor.on('close', next);
+				fs.createReadStream(context.archive).pipe(extractor);
+			}
+		} catch(err) {
+			next(err);
 		}
-		next();
+	}
+
+	function _removeExcludedFiles(context, next) {
+		log.silly("Generator#_removeExcludedFiles()");
+		async.forEach(context.item.excluded || [], function(excluded, next) {
+			var f = path.join(context.workDir, excluded);
+			log.silly("Generator#_removeExcludedFiles()", "rm -rf", f);
+			rimraf(f, next);
+		}, next);
         }
 
-	function _prefix(item, srcDir, dstDir, options, next) {
-		log.verbose("generate#_prefix()", "item:", item);
-		var src = path.join(srcDir, item.prefixToRemove);
-		var dst = path.join(dstDir, item.prefixToAdd);
+	function _prefix(context, next) {
+		log.silly("generate#_prefix()", "item:", context.item);
+		var src = context.item.prefixToRemove ? path.join(context.workDir, context.item.prefixToRemove) : context.workDir;
+		var dst = context.item.prefixToAdd ? path.join(context.destDir, context.item.prefixToAdd) : context.destDir;
 		log.verbose("generate#_prefix()", "src:", src, "-> dst:", dst);
 		async.waterfall([
 			function(next) {
-				fs.exists(dst, function(exists) { next(null, exists); });
+				log.silly("generate#_prefix#mkdirp()", dst);
+				mkdirp(dst, next);
 			},
-			_renameDst.bind(this),
-			mkdirp.bind(this),
-			function(data, next) { fs.readdir(src, next); },
-			_mv.bind(this),
-			_rm.bind(this, srcDir)
+			function(data, next) {
+				log.silly("generate#_prefix#fs.readdir()", src);
+				fs.readdir(src, next);
+			},
+			_mv.bind(this)
 		], next);
-
-		function _renameDst(exist, next) {
-			if (exist && options.overwrite === false) {
-				if (!item.prefixToAdd) { 
-					//no prefixToAdd, ignore it to prevent a invalid overwriting.
-					next();
-					return;
-				}
-				//find uniqName & change dstDir
-				dstDir = path.join(dst, "..");
-				var files = fs.readdirSync(dstDir);
-				var baseName = path.basename(dst);
-				baseName = _findUniqName(files, baseName, 2);
-				dst = path.join(dstDir, baseName);
-			}
-			next(null, dst);
-		}
 
 		function _mv(files, next) {
 			log.silly("generate#_prefix#_mv()", "files:", files);
@@ -291,23 +313,6 @@ var shell = require("shelljs"),
 				log.silly("generate#_prefix#_mv()", file + " -> " + dst);
 				fs.rename(path.join(src, file), path.join(dst, file), next);
 			}, next);
-		}
-
-		function _rm(file, next) {
-			fs.exists(file, function(exists) {
-				if (exists) {
-					rimraf(file, next);
-				}
-			}, next);
-		}
-
-		function _findUniqName(namelist, name, concatNum) {
-			var uniqName = name + concatNum.toString();
-			if (namelist.indexOf(uniqName) >= 0) {
-				return _findUniqName(namelist, name, concatNum+1);
-			} else {
-				return uniqName;
-			}
 		}
 	}
 

--- a/ares-generator.js
+++ b/ares-generator.js
@@ -16,8 +16,6 @@ var shell = require("shelljs"),
 
 	var generator = {};
 
-	var NODE_V_0_8 = !!process.version.match('^v0.8');
-
 	if (typeof module !== 'undefined' && module.exports) {
 		module.exports = generator;
 	}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -114,10 +114,6 @@
                   "from": "delayed-stream@0.0.5"
                 }
               }
-            },
-            "async": {
-              "version": "0.2.9",
-              "from": "async@~0.2.9"
             }
           }
         }
@@ -154,14 +150,20 @@
       }
     },
     "unzip": {
-      "version": "0.1.8",
-      "from": "unzip@0.1.8",
-      "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.8.tgz",
+      "version": "0.1.7-1",
       "dependencies": {
         "fstream": {
           "version": "0.1.24",
           "from": "fstream@~0.1.21",
           "dependencies": {
+            "rimraf": {
+              "version": "2.2.2",
+              "from": "rimraf@2"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@~0.3"
+            },
             "graceful-fs": {
               "version": "2.0.0",
               "from": "graceful-fs@~2.0.0"
@@ -216,11 +218,136 @@
         },
         "match-stream": {
           "version": "0.0.2",
-          "from": "match-stream@~0.0.2",
+          "from": "match-stream@git://github.com/EvanOxfeld/match-stream.git#callback-on-finish-wip",
+          "resolved": "git://github.com/EvanOxfeld/match-stream.git#070b5202a3a9250551ecab83c24f95f3bcf6a938",
           "dependencies": {
             "buffers": {
               "version": "0.1.1",
               "from": "buffers@~0.1.1"
+            }
+          }
+        },
+        "stream-buffers": {
+          "version": "0.2.5",
+          "from": "stream-buffers@~0.2.3"
+        },
+        "temp": {
+          "version": "0.4.0",
+          "from": "temp@~0.4.0"
+        },
+        "dirdiff": {
+          "version": "0.0.1",
+          "from": "dirdiff@~0.0.1",
+          "dependencies": {
+            "glob": {
+              "version": "3.1.21",
+              "from": "glob@~3.1.12",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.12",
+                  "from": "minimatch@~0.2.11",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.3.0",
+                      "from": "lru-cache@2"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "1.2.3",
+                  "from": "graceful-fs@~1.2.0"
+                },
+                "inherits": {
+                  "version": "1.0.0",
+                  "from": "inherits@1"
+                }
+              }
+            }
+          }
+        },
+        "tap": {
+          "version": "0.3.3",
+          "from": "tap@~0.3.0",
+          "dependencies": {
+            "inherits": {
+              "version": "1.0.0"
+            },
+            "yamlish": {
+              "version": "0.0.5"
+            },
+            "slide": {
+              "version": "1.1.4",
+              "from": "slide@*"
+            },
+            "runforcover": {
+              "version": "0.0.2",
+              "from": "runforcover@~0.0.2",
+              "dependencies": {
+                "bunker": {
+                  "version": "0.1.2",
+                  "from": "bunker@0.1.X",
+                  "dependencies": {
+                    "burrito": {
+                      "version": "0.2.12",
+                      "from": "burrito@>=0.2.5 <0.3",
+                      "dependencies": {
+                        "traverse": {
+                          "version": "0.5.2",
+                          "from": "traverse@~0.5.1"
+                        },
+                        "uglify-js": {
+                          "version": "1.1.1",
+                          "from": "uglify-js@~1.1.1"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "2.1.2",
+              "from": "nopt@~2",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.4",
+                  "from": "abbrev@1"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@~0.3"
+            },
+            "difflet": {
+              "version": "0.2.6",
+              "from": "difflet@~0.2.0",
+              "dependencies": {
+                "traverse": {
+                  "version": "0.6.3",
+                  "from": "traverse@0.6.x"
+                },
+                "charm": {
+                  "version": "0.1.2",
+                  "from": "charm@0.1.x"
+                },
+                "deep-is": {
+                  "version": "0.1.2",
+                  "from": "deep-is@0.1.x"
+                }
+              }
+            },
+            "deep-equal": {
+              "version": "0.0.0",
+              "from": "deep-equal@~0.0.0"
+            },
+            "buffer-equal": {
+              "version": "0.0.0",
+              "from": "buffer-equal@~0.0.0"
             }
           }
         }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,38 +1,109 @@
 {
   "name": "ares-generator",
-  "version": "0.1.7",
+  "version": "0.2.2",
   "dependencies": {
     "async": {
-      "version": "0.1.22",
-      "from": "async@0.1.22",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+      "version": "0.2.9",
+      "from": "async@0.2.9"
     },
     "mkdirp": {
       "version": "0.3.5",
-      "from": "mkdirp@0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+      "from": "mkdirp@0.3.x"
     },
     "npmlog": {
-      "version": "0.0.3",
-      "from": "https://registry.npmjs.org/npmlog/-/npmlog-0.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.0.3.tgz",
+      "version": "0.0.4",
+      "from": "npmlog@0.0.4",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.0.4.tgz",
       "dependencies": {
         "ansi": {
           "version": "0.1.2",
-          "from": "ansi@0.1.2",
-          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.1.2.tgz"
+          "from": "ansi@~0.1.2"
         }
       }
     },
     "request": {
-      "version": "2.12.0",
-      "from": "request@2.12.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.12.0.tgz",
+      "version": "2.26.0",
+      "from": "request@2.26.0",
       "dependencies": {
+        "qs": {
+          "version": "0.6.5",
+          "from": "qs@~0.6.0"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.0",
+          "from": "json-stringify-safe@~5.0.0"
+        },
+        "forever-agent": {
+          "version": "0.5.0",
+          "from": "forever-agent@~0.5.0"
+        },
+        "tunnel-agent": {
+          "version": "0.3.0",
+          "from": "tunnel-agent@~0.3.0"
+        },
+        "http-signature": {
+          "version": "0.10.0",
+          "from": "http-signature@~0.10.0",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.1.2",
+              "from": "assert-plus@0.1.2"
+            },
+            "asn1": {
+              "version": "0.1.11",
+              "from": "asn1@0.1.11"
+            },
+            "ctype": {
+              "version": "0.5.2",
+              "from": "ctype@0.5.2"
+            }
+          }
+        },
+        "hawk": {
+          "version": "1.0.0",
+          "from": "hawk@~1.0.0",
+          "dependencies": {
+            "hoek": {
+              "version": "0.9.1",
+              "from": "hoek@0.9.x"
+            },
+            "boom": {
+              "version": "0.4.2",
+              "from": "boom@0.4.x"
+            },
+            "cryptiles": {
+              "version": "0.2.2",
+              "from": "cryptiles@0.2.x"
+            },
+            "sntp": {
+              "version": "0.2.4",
+              "from": "sntp@0.2.x"
+            }
+          }
+        },
+        "aws-sign": {
+          "version": "0.3.0",
+          "from": "aws-sign@~0.3.0"
+        },
+        "oauth-sign": {
+          "version": "0.3.0",
+          "from": "oauth-sign@~0.3.0"
+        },
+        "cookie-jar": {
+          "version": "0.3.0",
+          "from": "cookie-jar@~0.3.0"
+        },
+        "node-uuid": {
+          "version": "1.4.0",
+          "from": "node-uuid@~1.4.0"
+        },
+        "mime": {
+          "version": "1.2.10",
+          "from": "mime@~1.2.9"
+        },
         "form-data": {
-          "version": "0.0.10",
-          "from": "form-data@0.0.10",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+          "version": "0.1.0",
+          "from": "form-data@~0.1.0",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.4",
@@ -40,69 +111,80 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "from": "delayed-stream@0.0.5"
                 }
               }
             },
             "async": {
               "version": "0.2.9",
-              "from": "async@~0.2.7",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+              "from": "async@~0.2.9"
             }
           }
-        },
-        "mime": {
-          "version": "1.2.9",
-          "from": "mime@1.2.9",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.9.tgz"
         }
       }
     },
     "rimraf": {
-      "version": "1.0.9",
-      "from": "rimraf@1.0.9",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-1.0.9.tgz"
+      "version": "2.2.2",
+      "from": "rimraf@2.2.2",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "2.0.0",
+          "from": "graceful-fs@~2"
+        }
+      }
     },
     "shelljs": {
       "version": "0.1.4",
-      "from": "shelljs@0.1.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz"
+      "from": "shelljs@0.1.x"
     },
     "temp": {
-      "version": "0.4.0",
-      "from": "temp@0.4.0",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz"
+      "version": "0.5.1",
+      "from": "temp@0.5.1",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.1.4",
+          "from": "rimraf@~2.1.4",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@~1"
+            }
+          }
+        }
+      }
     },
     "unzip": {
-      "version": "0.1.3",
+      "version": "0.1.8",
+      "from": "unzip@0.1.8",
+      "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.8.tgz",
       "dependencies": {
         "fstream": {
-          "version": "0.1.22",
+          "version": "0.1.24",
           "from": "fstream@~0.1.21",
           "dependencies": {
-            "rimraf": {
-              "version": "2.2.0",
-              "from": "rimraf@2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.0.tgz"
-            },
-            "mkdirp": {
-              "version": "0.3.5",
-              "from": "mkdirp@~0.3"
-            },
             "graceful-fs": {
-              "version": "1.2.2",
-              "from": "graceful-fs@~1.2.0"
+              "version": "2.0.0",
+              "from": "graceful-fs@~2.0.0"
             },
             "inherits": {
-              "version": "1.0.0",
-              "from": "inherits@1"
+              "version": "2.0.0",
+              "from": "inherits@~2.0.0"
             }
           }
         },
         "pullstream": {
-          "version": "0.1.0",
-          "from": "pullstream@~0.1.0"
+          "version": "0.4.0",
+          "from": "pullstream@~0.4.0",
+          "dependencies": {
+            "over": {
+              "version": "0.0.5",
+              "from": "over@~0.0.5"
+            },
+            "slice-stream": {
+              "version": "0.0.0",
+              "from": "slice-stream@0.0.0"
+            }
+          }
         },
         "binary": {
           "version": "0.3.0",
@@ -117,147 +199,28 @@
                   "from": "traverse@>=0.3.0 <0.4"
                 }
               }
+            },
+            "buffers": {
+              "version": "0.1.1",
+              "from": "buffers@~0.1.1"
             }
           }
         },
         "readable-stream": {
-          "version": "0.2.0",
-          "from": "readable-stream@~0.2.0"
+          "version": "1.0.15",
+          "from": "readable-stream@~1.0.0"
         },
         "setimmediate": {
           "version": "1.0.1",
           "from": "setimmediate@~1.0.1"
         },
-        "buffers": {
-          "version": "0.1.1",
-          "from": "buffers@~0.1.1"
-        },
-        "over": {
-          "version": "0.0.5",
-          "from": "over@0.0.5",
-          "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz"
-        },
-        "temp": {
-          "version": "0.4.0",
-          "from": "temp@~0.4.0"
-        },
-        "stream-buffers": {
-          "version": "0.2.4",
-          "from": "stream-buffers@~0.2.3"
-        },
-        "dirdiff": {
-          "version": "0.0.1",
-          "from": "dirdiff@~0.0.1",
+        "match-stream": {
+          "version": "0.0.2",
+          "from": "match-stream@~0.0.2",
           "dependencies": {
-            "glob": {
-              "version": "3.1.21",
-              "from": "glob@~3.1.12",
-              "dependencies": {
-                "minimatch": {
-                  "version": "0.2.12",
-                  "from": "minimatch@~0.2.11",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.3.0",
-                      "from": "lru-cache@2"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@~1.0.0"
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "1.2.2",
-                  "from": "graceful-fs@~1.2.0"
-                },
-                "inherits": {
-                  "version": "1.0.0",
-                  "from": "inherits@1"
-                }
-              }
-            }
-          }
-        },
-        "tap": {
-          "version": "0.3.3",
-          "from": "tap@~0.3.0",
-          "dependencies": {
-            "inherits": {
-              "version": "1.0.0"
-            },
-            "yamlish": {
-              "version": "0.0.5"
-            },
-            "slide": {
-              "version": "1.1.4",
-              "from": "slide@*"
-            },
-            "runforcover": {
-              "version": "0.0.2",
-              "from": "runforcover@~0.0.2",
-              "dependencies": {
-                "bunker": {
-                  "version": "0.1.2",
-                  "from": "bunker@0.1.X",
-                  "dependencies": {
-                    "burrito": {
-                      "version": "0.2.12",
-                      "from": "burrito@>=0.2.5 <0.3",
-                      "dependencies": {
-                        "traverse": {
-                          "version": "0.5.2",
-                          "from": "traverse@~0.5.1"
-                        },
-                        "uglify-js": {
-                          "version": "1.1.1",
-                          "from": "uglify-js@~1.1.1"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "2.1.1",
-              "from": "nopt@~2",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.4",
-                  "from": "abbrev@1"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.3.5",
-              "from": "mkdirp@~0.3"
-            },
-            "difflet": {
-              "version": "0.2.5",
-              "from": "difflet@~0.2.0",
-              "dependencies": {
-                "traverse": {
-                  "version": "0.6.3",
-                  "from": "traverse@0.6.x"
-                },
-                "charm": {
-                  "version": "0.0.8",
-                  "from": "charm@0.0.x"
-                },
-                "deep-is": {
-                  "version": "0.1.2",
-                  "from": "deep-is@0.1.x"
-                }
-              }
-            },
-            "deep-equal": {
-              "version": "0.0.0",
-              "from": "deep-equal@~0.0.0"
-            },
-            "buffer-equal": {
-              "version": "0.0.0",
-              "from": "buffer-equal@~0.0.0"
+            "buffers": {
+              "version": "0.1.1",
+              "from": "buffers@~0.1.1"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
 		"url" : "http://github.com/enyojs/ares-generator.git"
 	},
 	"engines": {
-		"node" : ">=0.8.21",
-		"npm": ">=1.2"
+		"node" : "~0.10.12",
+		"npm": "~1.2"
 	},
 	"engineStrict": true,
 	"os" : [ "darwin", "linux", "win32" ],
@@ -26,7 +26,7 @@
 		"rimraf": "~2.2.2",
 		"shelljs": "~0.1.4",
 		"temp": "~0.5.1",
-		"unzip": "~0.1.8"
+		"unzip": "0.1.7-1"
 	},
 	"bundledDependencies": [
 		"async",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ares-generator",
 	"main": "./ares-generator.js",
-	"version": "0.1.7",
+	"version": "0.2.2",
 	"description": "Project-generation toolkit for the ares-ide EnyoJS IDE",
 	"keywords": ["ares-ide", "enyo"],
 	"homepage": "https://github.com/enyojs/ares-generator",
@@ -13,20 +13,20 @@
 		"url" : "http://github.com/enyojs/ares-generator.git"
 	},
 	"engines": {
-		"node" : "0.8.x >=0.8.21",
-		"npm": "1.2.x"
+		"node" : ">=0.8.21",
+		"npm": ">=1.2"
 	},
 	"engineStrict": true,
 	"os" : [ "darwin", "linux", "win32" ],
 	"dependencies": {
-		"async": "0.1.x",
-		"mkdirp": "0.3.x",
-		"npmlog": "0.0.x",
-		"request": "2.12.x",
-		"rimraf": "1.0.x",
-		"shelljs": "0.1.x",
-		"temp": "0.4.x",
-		"unzip": "0.1.3"
+		"async": "~0.2.9",
+		"mkdirp": "~0.3.5",
+		"npmlog": "~0.0.4",
+		"request": "~2.26.0",
+		"rimraf": "~2.2.2",
+		"shelljs": "~0.1.4",
+		"temp": "~0.5.1",
+		"unzip": "~0.1.8"
 	},
 	"bundledDependencies": [
 		"async",
@@ -39,9 +39,9 @@
 		"unzip"
 	],
 	"devDependencies": {
-		"mocha": ">=1.4.2",
-		"should": ">=1.1.0",
-		"jshint": ">=2.1.3"
+		"mocha": "~1.4.2",
+		"should": "~1.1.0",
+		"jshint": "~2.1.3"
 	},
 	"scripts" : {
 		"install" : "node ./scripts/sub-npm.js",


### PR DESCRIPTION
Tested on OSX. I do not expect any change on Linux or Windows.

**Demands** Node.js 0.10 (See https://enyojs.atlassian.net/browse/ENYO-2063 for details).
- ENYO-2063: clean-up needless `nodejs@0.8` code path (HEAD, origin/ENYO-2063, ENYO-2063)
- ENYO-2063: update npm dependencies & associated shrinkwrap
- ENYO-2063: use new patched node-unzip (0.1.7 + changes) for nodejs@0.10
- ENYO-2063: re-add node-unzip as submodule
- ENYO-2063: improve the overwrite, split fetch+unzip
- ENYO-2063: remove dependency on patched node-unzip

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
