### PR TITLE
ENYO-2904: replace dependency on `node-unzip` by `node-zip`|`JSZip`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "node_modules/unzip"]
-	path = node_modules/unzip
-	url = ../../enyojs/node-unzip.git

--- a/ares-generator.js
+++ b/ares-generator.js
@@ -291,7 +291,7 @@ var shell = require("shelljs"),
 									encoding = 'utf8';
 								}
 								var buf = new Buffer(file.data, encoding);
-								fs.writeFile(file.name, buf, next);
+								fs.writeFile(fileName, buf, next);
 							}
 						}
 					], next);

--- a/ares-generator.js
+++ b/ares-generator.js
@@ -271,7 +271,7 @@ var shell = require("shelljs"),
 				log.silly("Generator#_unzipFile()", 'ar:', util.inspect(Object.keys(ar)));
 				log.silly("Generator#_unzipFile()", 'ar.root:', ar.root);
 				async.forEachSeries(Object.keys(ar.files), function(fileKey, next) {
-					var file = ar.files[fileKey];
+					var file = ar.files[fileKey], encoding;
 					log.silly("Generator#_unzipFile()", "file.name:", file.name);
 					log.silly("Generator#_unzipFile()", "file.options:", file.options);
 					var fileName = path.join(context.workDir, file.name);
@@ -283,14 +283,21 @@ var shell = require("shelljs"),
 								fs.mkdir(fileName, next);
 							} else {
 								log.silly("Generator#_unzipFile()", "write", fileName);
-								fs.writeFile(fileName, file.data, next);
+								if (file.options.binary) {
+									encoding = 'binary';
+								} else if (file.options.base64) {
+									encoding = 'base64';
+								} else {
+									encoding = 'utf8';
+								}
+								var buf = new Buffer(file.data, encoding);
+								fs.writeFile(file.name, buf, next);
 							}
 						}
 					], next);
 				}, next);
 			}
 		], next);
-
 	}
 
 	function _removeExcludedFiles(context, next) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,19 +4,21 @@
   "dependencies": {
     "async": {
       "version": "0.2.9",
-      "from": "async@~0.2.9"
+      "from": "async@0.2.9"
     },
     "mkdirp": {
       "version": "0.3.5",
-      "from": "mkdirp@~0.3.5"
+      "from": "mkdirp@0.3.x"
     },
     "node-zip": {
       "version": "1.0.1",
-      "from": "node-zip@~1.0.1"
+      "from": "node-zip@1.0.1",
+      "resolved": "https://registry.npmjs.org/node-zip/-/node-zip-1.0.1.tgz"
     },
     "npmlog": {
       "version": "0.0.4",
-      "from": "npmlog@~0.0.4",
+      "from": "npmlog@0.0.4",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.0.4.tgz",
       "dependencies": {
         "ansi": {
           "version": "0.1.2",
@@ -26,7 +28,7 @@
     },
     "request": {
       "version": "2.26.0",
-      "from": "request@~2.26.0",
+      "from": "request@2.26.0",
       "dependencies": {
         "qs": {
           "version": "0.6.5",
@@ -124,7 +126,7 @@
     },
     "rimraf": {
       "version": "2.2.2",
-      "from": "rimraf@~2.2.2",
+      "from": "rimraf@2.2.2",
       "dependencies": {
         "graceful-fs": {
           "version": "2.0.0",
@@ -134,11 +136,11 @@
     },
     "shelljs": {
       "version": "0.1.4",
-      "from": "shelljs@~0.1.4"
+      "from": "shelljs@0.1.x"
     },
     "temp": {
       "version": "0.5.1",
-      "from": "temp@~0.5.1",
+      "from": "temp@0.5.1",
       "dependencies": {
         "rimraf": {
           "version": "2.1.4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,18 +4,19 @@
   "dependencies": {
     "async": {
       "version": "0.2.9",
-      "from": "async@0.2.9",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+      "from": "async@~0.2.9"
     },
     "mkdirp": {
       "version": "0.3.5",
-      "from": "mkdirp@0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+      "from": "mkdirp@~0.3.5"
+    },
+    "node-zip": {
+      "version": "1.0.1",
+      "from": "node-zip@~1.0.1"
     },
     "npmlog": {
       "version": "0.0.4",
-      "from": "npmlog@0.0.4",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.0.4.tgz",
+      "from": "npmlog@~0.0.4",
       "dependencies": {
         "ansi": {
           "version": "0.1.2",
@@ -25,107 +26,87 @@
     },
     "request": {
       "version": "2.26.0",
-      "from": "request@2.26.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.26.0.tgz",
+      "from": "request@~2.26.0",
       "dependencies": {
         "qs": {
           "version": "0.6.5",
-          "from": "qs@0.6.5",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz"
+          "from": "qs@~0.6.0"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@~5.0.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+          "from": "json-stringify-safe@~5.0.0"
         },
         "forever-agent": {
           "version": "0.5.0",
-          "from": "forever-agent@~0.5.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.0.tgz"
+          "from": "forever-agent@~0.5.0"
         },
         "tunnel-agent": {
           "version": "0.3.0",
-          "from": "tunnel-agent@~0.3.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+          "from": "tunnel-agent@~0.3.0"
         },
         "http-signature": {
           "version": "0.10.0",
           "from": "http-signature@~0.10.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.2",
-              "from": "assert-plus@0.1.2",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+              "from": "assert-plus@0.1.2"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+              "from": "asn1@0.1.11"
             },
             "ctype": {
               "version": "0.5.2",
-              "from": "ctype@0.5.2",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+              "from": "ctype@0.5.2"
             }
           }
         },
         "hawk": {
           "version": "1.0.0",
           "from": "hawk@~1.0.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "hoek@0.9.x",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+              "from": "hoek@0.9.x"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "boom@0.4.x",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+              "from": "boom@0.4.x"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "cryptiles@0.2.x",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+              "from": "cryptiles@0.2.x"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "sntp@0.2.x",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+              "from": "sntp@0.2.x"
             }
           }
         },
         "aws-sign": {
           "version": "0.3.0",
-          "from": "aws-sign@~0.3.0",
-          "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
+          "from": "aws-sign@~0.3.0"
         },
         "oauth-sign": {
           "version": "0.3.0",
-          "from": "oauth-sign@~0.3.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+          "from": "oauth-sign@~0.3.0"
         },
         "cookie-jar": {
           "version": "0.3.0",
-          "from": "cookie-jar@~0.3.0",
-          "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
+          "from": "cookie-jar@~0.3.0"
         },
         "node-uuid": {
           "version": "1.4.0",
-          "from": "node-uuid@~1.4.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.0.tgz"
+          "from": "node-uuid@~1.4.0"
         },
         "mime": {
           "version": "1.2.10",
-          "from": "mime@~1.2.9",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.10.tgz"
+          "from": "mime@~1.2.9"
         },
         "form-data": {
           "version": "0.1.0",
           "from": "form-data@~0.1.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.0.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.4",
@@ -133,15 +114,9 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "from": "delayed-stream@0.0.5"
                 }
               }
-            },
-            "async": {
-              "version": "0.2.9",
-              "from": "async@~0.2.9",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
             }
           }
         }
@@ -149,25 +124,21 @@
     },
     "rimraf": {
       "version": "2.2.2",
-      "from": "rimraf@2.2.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.2.tgz",
+      "from": "rimraf@~2.2.2",
       "dependencies": {
         "graceful-fs": {
           "version": "2.0.0",
-          "from": "graceful-fs@~2.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.0.tgz"
+          "from": "graceful-fs@~2"
         }
       }
     },
     "shelljs": {
       "version": "0.1.4",
-      "from": "shelljs@0.1.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz"
+      "from": "shelljs@~0.1.4"
     },
     "temp": {
       "version": "0.5.1",
-      "from": "temp@0.5.1",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.5.1.tgz",
+      "from": "temp@~0.5.1",
       "dependencies": {
         "rimraf": {
           "version": "2.1.4",
@@ -175,212 +146,7 @@
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-            }
-          }
-        }
-      }
-    },
-    "unzip": {
-      "version": "0.1.7-1",
-      "dependencies": {
-        "fstream": {
-          "version": "0.1.24",
-          "from": "fstream@0.1.24",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.24.tgz",
-          "dependencies": {
-            "rimraf": {
-              "version": "2.2.2",
-              "from": "rimraf@2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.2.tgz"
-            },
-            "mkdirp": {
-              "version": "0.3.5",
-              "from": "mkdirp@0.3"
-            },
-            "graceful-fs": {
-              "version": "2.0.0",
-              "from": "graceful-fs@~2.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.0.tgz"
-            },
-            "inherits": {
-              "version": "2.0.0",
-              "from": "inherits@~2.0.0"
-            }
-          }
-        },
-        "pullstream": {
-          "version": "0.4.0",
-          "from": "pullstream@~0.4.0",
-          "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.0.tgz",
-          "dependencies": {
-            "slice-stream": {
-              "version": "0.0.0",
-              "from": "slice-stream@0.0.0",
-              "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-0.0.0.tgz"
-            }
-          }
-        },
-        "binary": {
-          "version": "0.3.0",
-          "from": "binary@~0.3.0",
-          "dependencies": {
-            "chainsaw": {
-              "version": "0.1.0",
-              "from": "chainsaw@~0.1.0",
-              "dependencies": {
-                "traverse": {
-                  "version": "0.3.9",
-                  "from": "traverse@>=0.3.0 <0.4"
-                }
-              }
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.15",
-          "from": "readable-stream@~1.0.0"
-        },
-        "setimmediate": {
-          "version": "1.0.1",
-          "from": "setimmediate@~1.0.1"
-        },
-        "match-stream": {
-          "version": "0.0.2",
-          "from": "match-stream@git://github.com/EvanOxfeld/match-stream.git#callback-on-finish-wip",
-          "resolved": "git://github.com/EvanOxfeld/match-stream.git#070b5202a3a9250551ecab83c24f95f3bcf6a938"
-        },
-        "buffers": {
-          "version": "0.1.1",
-          "from": "buffers@~0.1.1"
-        },
-        "over": {
-          "version": "0.0.5",
-          "from": "over@0.0.5",
-          "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz"
-        },
-        "stream-buffers": {
-          "version": "0.2.4",
-          "from": "stream-buffers@~0.2.3"
-        },
-        "temp": {
-          "version": "0.4.0",
-          "from": "temp@~0.4.0"
-        },
-        "dirdiff": {
-          "version": "0.0.1",
-          "from": "dirdiff@~0.0.1",
-          "dependencies": {
-            "glob": {
-              "version": "3.1.21",
-              "from": "glob@~3.1.12",
-              "dependencies": {
-                "minimatch": {
-                  "version": "0.2.12",
-                  "from": "minimatch@~0.2.11",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.3.0",
-                      "from": "lru-cache@2"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@~1.0.0"
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "1.2.2",
-                  "from": "graceful-fs@~1.2.0"
-                },
-                "inherits": {
-                  "version": "1.0.0",
-                  "from": "inherits@1"
-                }
-              }
-            }
-          }
-        },
-        "tap": {
-          "version": "0.3.3",
-          "from": "tap@~0.3.0",
-          "dependencies": {
-            "inherits": {
-              "version": "1.0.0"
-            },
-            "yamlish": {
-              "version": "0.0.5"
-            },
-            "slide": {
-              "version": "1.1.4",
-              "from": "slide@*"
-            },
-            "runforcover": {
-              "version": "0.0.2",
-              "from": "runforcover@~0.0.2",
-              "dependencies": {
-                "bunker": {
-                  "version": "0.1.2",
-                  "from": "bunker@0.1.X",
-                  "dependencies": {
-                    "burrito": {
-                      "version": "0.2.12",
-                      "from": "burrito@>=0.2.5 <0.3",
-                      "dependencies": {
-                        "traverse": {
-                          "version": "0.5.2",
-                          "from": "traverse@~0.5.1"
-                        },
-                        "uglify-js": {
-                          "version": "1.1.1",
-                          "from": "uglify-js@~1.1.1"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "2.1.1",
-              "from": "nopt@~2",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.4",
-                  "from": "abbrev@1"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.3.5",
-              "from": "mkdirp@~0.3"
-            },
-            "difflet": {
-              "version": "0.2.5",
-              "from": "difflet@~0.2.0",
-              "dependencies": {
-                "traverse": {
-                  "version": "0.6.3",
-                  "from": "traverse@0.6.x"
-                },
-                "charm": {
-                  "version": "0.0.8",
-                  "from": "charm@0.0.x"
-                },
-                "deep-is": {
-                  "version": "0.1.2",
-                  "from": "deep-is@0.1.x"
-                }
-              }
-            },
-            "deep-equal": {
-              "version": "0.0.0",
-              "from": "deep-equal@~0.0.0"
-            },
-            "buffer-equal": {
-              "version": "0.0.0",
-              "from": "buffer-equal@~0.0.0"
+              "from": "graceful-fs@~1"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
 		"url" : "http://github.com/enyojs/ares-generator.git"
 	},
 	"engines": {
-		"node" : "~0.10.12",
-		"npm": "~1.2"
+		"node" : ">=0.8.21",
+		"npm": ">=1.2.11"
 	},
 	"engineStrict": true,
 	"os" : [ "darwin", "linux", "win32" ],

--- a/package.json
+++ b/package.json
@@ -21,22 +21,22 @@
 	"dependencies": {
 		"async": "~0.2.9",
 		"mkdirp": "~0.3.5",
+		"node-zip": "~1.0.1",
 		"npmlog": "~0.0.4",
 		"request": "~2.26.0",
 		"rimraf": "~2.2.2",
 		"shelljs": "~0.1.4",
-		"temp": "~0.5.1",
-		"unzip": "0.1.7-1"
+		"temp": "~0.5.1"
 	},
 	"bundledDependencies": [
 		"async",
 		"mkdirp",
+		"node-zip",
 		"npmlog",
 		"request",
 		"rimraf",
 		"shelljs",
-		"temp",
-		"unzip"
+		"temp"
 	],
 	"devDependencies": {
 		"mocha": "~1.4.2",

--- a/scripts/sub-npm.js
+++ b/scripts/sub-npm.js
@@ -4,7 +4,6 @@ var path = require('path'),
     spawn = require('child_process').spawn;
 
 var submodules = [
-	'node_modules/unzip'
 ];
 
 var mwd = process.cwd();

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,75 @@
+var nodezip = require('node-zip'),
+    request = require('request'),
+    util = require('util'),
+    path = require('path'),
+    fs = require('fs'),
+    log = require('npmlog'),
+    mkdirp = require('mkdirp'),
+    async = require('async');
+
+log.level ='silly';
+
+var url = "http://enyojs.com/archive/bootplate-2.2.0.zip",
+    archive = path.basename(url);
+
+async.series([
+	/*
+	function(next) {
+		request({
+			url: url,
+			proxy: process.env['https_proxy']
+		}).pipe(
+			fs.createWriteStream("bootplate-2.2.0.zip").on('close', next)
+		);
+	},
+	 */
+	function(next) {
+		async.waterfall([
+			fs.readFile.bind(fs, archive, 'binary'),
+			function(arBuf, next) {
+				log.verbose("arBuf.length:", arBuf.length);
+				var ar;
+				try {
+					ar = new nodezip(arBuf, { base64: false, checkCRC32: false });
+				} catch(err) {
+					next(err);
+				}
+				log.verbose('ar:', util.inspect(Object.keys(ar)));
+				log.verbose('typeof ar.root:', typeof ar.root);
+				log.verbose('ar.root:', ar.root);
+				async.forEachSeries(Object.keys(ar.files), function(fileKey, next) {
+					var file = ar.files[fileKey], encoding;
+					log.silly("file.name:", file.name);
+					log.silly("file.options:", file.options);
+					async.series([
+						mkdirp.bind(null, path.dirname(file.name)),
+						function(next) {
+							if (file.options.dir) {
+								log.silly("mkdir", file.name);
+								fs.mkdir(file.name, next);
+							} else {
+								log.silly("write", file.name);
+								if (file.options.binary) {
+									encoding = 'binary';
+								} else if (file.options.base64) {
+									encoding = 'base64';
+								} else {
+									encoding = 'utf8';
+								}
+								var buf = new Buffer(file.data, encoding);
+								fs.writeFile(file.name, buf, next);
+							}
+						}
+					], next);
+				}, next);
+			}
+		], next);
+	}
+], function(err) {
+	if (err) {
+		log.error(err);
+	} else {
+		log.info('ok');
+	}
+});
+


### PR DESCRIPTION
- no more stream-based unzipping: the entire ZIP archive is now loaded
  in memory (as a Buffer).
- note to reviewer: `_unzipFile()` is indeed kept as a single function (even with multiple nested `async.*`) to keep it on a single page.

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
