### PR TITLE
ENYO-2935: support isDefault property for the template source

### DIFF
--- a/ares-generator.js
+++ b/ares-generator.js
@@ -119,6 +119,7 @@ var fs = require("graceful-fs"),
 					id: source.id,
 					version: source.version,
 					description: source.description,
+					isDefault: source.isDefault || false,
 					deps: source.deps || []
 				};
 			});


### PR DESCRIPTION
- `ares-generator.getSources()` return new `isDefault:` property if  `ide.json` or `ide-plugins.json` has it, default value is false.

Enyo-DCO-1.1-Signed-off-by: Junil Kim logyourself@gmail.com
