### PR TITLE
ENYO-3485: bug fix regarding temp node module to make directory under temp path (defect on ubuntu)

### DIFF
--- a/ares-generator.js
+++ b/ares-generator.js
@@ -200,13 +200,12 @@ var fs = require("graceful-fs"),
 				return;
 			}
 
-			async.waterfall([
-				temp.mkdir.bind(null, {
-					prefix: 'com.enyojs.ares.generator.',
-					suffix: ".d"
-				}),
-				function(tmpDir, next) {
-					session.tmpDir = tmpDir;
+			async.series([
+				function(next) {
+					session.tmpDir = temp.path({prefix: 'com.enyojs.ares.generator.', suffix: '.d'});
+					mkdirp(session.tmpDir, next);
+				},
+				function(next) {
 					log.silly("generate()", "session.tmpDir:", session.tmpDir);
 					setImmediate(next);
 				},		


### PR DESCRIPTION
- bug fix regarding temp node module to make directory under temp path (defect on ubuntu).
- When there is no proper global variable about temp path, temp node module assume that $HOME/tmp as a temp path, but if there is no directory at that location, it cause error when `temp.mkdir()` function is called.

Enyo-DCO-1.1-Signed-off-by:: Junil Kim logyourself@gmail.com
