### PR TITLE
ENYO-3672: fix bugs regarding substitution

### DIFF
--- a/ares-generator.js
+++ b/ares-generator.js
@@ -596,7 +596,7 @@ var fs = require("graceful-fs"),
 				function(content, next) {
 					Object.keys(changes).forEach(function(key) {
 						var value = changes[key];
-						log.silly("_applyRegexpSubstitutions()", "word=" + key + " -> value=" + value);
+						log.silly("_applyRegexpSubstitutions()", "regexp=" + key + " -> value=" + value);
 						var regExp = new RegExp(key, "g");
 						content = content.replace(regExp, value);
 					});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ares-generator",
 	"main": "./ares-generator.js",
-	"version": "0.2.4",
+	"version": "0.3.4",
 	"description": "Project-generation toolkit for the ares-ide EnyoJS IDE",
 	"keywords": ["ares-ide", "enyo"],
 	"homepage": "https://github.com/enyojs/ares-generator",


### PR DESCRIPTION
Changes
- added substitution.regexp for applying substitution using regexp.
- can use  substit.json, substit.vars and substit.regexp together

Enyo-DCO-1.1-Signed-off-by Junil Kim logyourself@gmail.com
