### PR TITLE
support symlink field in 'files'

### DIFF
--- a/ares-generator.js
+++ b/ares-generator.js
@@ -10,7 +10,7 @@ var fs = require("graceful-fs"),
     async = require("async"),
     mkdirp = require("mkdirp"),
     AdmZip = require("adm-zip"),
-    copyFile = require('./copyFile');
+    copyFile = require('./copyFile'),
     copyDir = require('./copyDir');
 
 (function () {
@@ -670,14 +670,15 @@ var fs = require("graceful-fs"),
 
 						function(next) {
 							if (fs.existsSync(dst)) {
-								next();
+							    setImmediate(next);
 							} else {
 								async.series([
 									fs.symlink.bind(null, link, dst, symlinkType)
 								], function(err, result) {
-									if (err && err.code === 'EPERM')
+									if (err && err.code === 'EPERM') {
 										return copyDir(link, dstDir, next);
-									next(err);
+                                    }
+							        setImmediate(next);
 								});
 							}
 						}

--- a/ares-generator.js
+++ b/ares-generator.js
@@ -11,6 +11,7 @@ var fs = require("graceful-fs"),
     mkdirp = require("mkdirp"),
     AdmZip = require("adm-zip"),
     copyFile = require('./copyFile');
+    copyDir = require('./copyDir');
 
 (function () {
 
@@ -133,6 +134,7 @@ var fs = require("graceful-fs"),
 			var self = this;
 			var session = {
 				fileList: [],
+				linkList: [],
 				substitutions: substitutions,
 				destination: destination
 			};
@@ -211,7 +213,8 @@ var fs = require("graceful-fs"),
 				},		
 				async.forEachSeries.bind(self, sources, _processSource.bind(self)),
 				_substitute.bind(self, session),
-				_realize.bind(self, session)
+				_realize.bind(self, session),
+				_symlink.bind(self, session)
 			], function _notifyCaller(err) {
 				if (err) {
 					// delete tmpDir & trampoline the error
@@ -256,6 +259,7 @@ var fs = require("graceful-fs"),
 					setImmediate(next);
 					return;
 				}
+				session.linkList = session.linkList.concat(item.symlink || []);
 				if ((path.extname(item.url).toLowerCase() === ".zip") ||
 				    (path.extname(item.alternateUrl).toLowerCase() === ".zip")) {
 					_processZipFile(item, _out);
@@ -623,5 +627,62 @@ var fs = require("graceful-fs"),
 		} else {
 			setImmediate(next);
 		}
+	}
+	function _symlink(session, next) {
+		var dstDir = session.destination,
+			linkList = session.linkList;
+		log.verbose("generate#_symlink()", "dstDir:", dstDir, "linkList.length:", linkList.length);
+		async.forEachSeries(linkList, __makeSymlink, next);
+
+		function __makeSymlink(symlinkObj, next) {
+			if (dstDir) {
+				var symNames = Object.keys(symlinkObj);
+				async.forEachSeries(symNames, function(name, next) {
+					var link = symlinkObj[name];
+					if (!link)
+						return next();
+					try {
+						var stat = fs.lstatSync(link);
+						var symlinkType;
+						if (stat.isDirectory()) {
+							symlinkType = 'dir';
+						} else if (stat.isFile()) {
+							symlinkType = 'file';
+						}
+						if (!symlinkType) setImmediate(next, new Error("Cannot recognize the file type of " + link));
+					} catch (err) {
+						if (err.code === "ENOENT") {
+							setImmediate(next, new Error("Cannot make a symlink for " + link));
+						} else {
+							setImmediate(next, err);
+						}
+					}
+					var dst = path.join(dstDir, name);
+					if (path.basename(path.dirname(path.resolve(dst))) !== path.basename(path.resolve(dstDir))) {
+						mkdirp.sync(path.dirname(path.resolve(dst)));
+					}
+					log.silly('generate#_symlink()', dst, "<-", link);
+					async.series([
+
+						function(next) {
+							if (fs.existsSync(dst)) {
+								next();
+							} else {
+								async.series([
+									fs.symlink.bind(null, link, dst, symlinkType)
+								], function(err, result) {
+									if (err && err.code === 'EPERM')
+										return copyDir(link, dstDir, next);
+									next(err);
+								});
+							}
+						}
+					], next);
+				}, next);
+			} else {
+				setImmediate(next);
+			}
+        }
+
 	}
 }());

--- a/ares-generator.js
+++ b/ares-generator.js
@@ -640,8 +640,8 @@ var fs = require("graceful-fs"),
 				async.forEachSeries(symNames, function(name, next) {
 					var link = symlinkObj[name];
 					if (!link) {
-                        return setImmediate(next);
-                    }
+						return setImmediate(next);
+					}
 					try {
 						var stat = fs.lstatSync(link);
 						var symlinkType;
@@ -651,15 +651,15 @@ var fs = require("graceful-fs"),
 							symlinkType = 'file';
 						}
 						if (!symlinkType) {
-                            return setImmediate(next, new Error("Cannot recognize the file type of " + link));
-                        }
+							return setImmediate(next, new Error("Cannot recognize the file type of " + link));
+						}
 					} catch (err) {
 						if (err.code === "ENOENT") {
 							setImmediate(next, new Error("Cannot make a symlink for " + link));
 						} else {
 							setImmediate(next, err);
 						}
-                        return;
+						return;
 					}
 					var dst = path.join(dstDir, name);
 					if (path.basename(path.dirname(path.resolve(dst))) !== path.basename(path.resolve(dstDir))) {
@@ -686,7 +686,6 @@ var fs = require("graceful-fs"),
 			} else {
 				setImmediate(next);
 			}
-        }
-
+		}
 	}
 }());

--- a/ares-generator.js
+++ b/ares-generator.js
@@ -639,8 +639,9 @@ var fs = require("graceful-fs"),
 				var symNames = Object.keys(symlinkObj);
 				async.forEachSeries(symNames, function(name, next) {
 					var link = symlinkObj[name];
-					if (!link)
-						return next();
+					if (!link) {
+                        return setImmediate(next);
+                    }
 					try {
 						var stat = fs.lstatSync(link);
 						var symlinkType;
@@ -649,13 +650,16 @@ var fs = require("graceful-fs"),
 						} else if (stat.isFile()) {
 							symlinkType = 'file';
 						}
-						if (!symlinkType) setImmediate(next, new Error("Cannot recognize the file type of " + link));
+						if (!symlinkType) {
+                            return setImmediate(next, new Error("Cannot recognize the file type of " + link));
+                        }
 					} catch (err) {
 						if (err.code === "ENOENT") {
 							setImmediate(next, new Error("Cannot make a symlink for " + link));
 						} else {
 							setImmediate(next, err);
 						}
+                        return;
 					}
 					var dst = path.join(dstDir, name);
 					if (path.basename(path.dirname(path.resolve(dst))) !== path.basename(path.resolve(dstDir))) {

--- a/copyDir.js
+++ b/copyDir.js
@@ -1,0 +1,36 @@
+/*jshint node: true, strict: false, globalstrict: false */
+
+module.exports = copySrcToDst;
+
+var fs = require('fs'),
+	path = require('path'),
+	shelljs = require('shelljs'),
+	Rsync = require('rsync');
+
+function copySrcToDst(src, dst, next) {
+    try {
+        if (process.platform === 'win32') {
+            try {
+                shelljs.cp('-rf', src, dst);
+                setImmediate(next);
+            } catch(err) {
+                setImmediate(next, err);
+            }
+        } else {
+            var rsync = new Rsync();
+            rsync.flags({
+                    'a': true,
+                    'r': true,
+                    'L': true,
+                    'v': false
+                });
+            //TODO: rsync npm module can't handle the path including blank.
+            //      So, the path should be surrounded with double quotes.
+            rsync.source('"'+src+'"')
+                .destination('"'+dst+'"');
+            rsync.execute(next);
+        }
+    } catch(err) {
+        setImmediate(next, err);
+    }
+}

--- a/copyDir.js
+++ b/copyDir.js
@@ -2,9 +2,7 @@
 
 module.exports = copySrcToDst;
 
-var fs = require('fs'),
-	path = require('path'),
-	shelljs = require('shelljs'),
+var shelljs = require('shelljs'),
 	Rsync = require('rsync');
 
 function copySrcToDst(src, dst, next) {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"README.md",
 		"ares-generator.js",
 		"copyFile.js",
+		"copyDir.js",
 		"scripts"
 	]
 }


### PR DESCRIPTION
```
                  {
                      "id": "bootplate-moonstone",
                      "type": "template",
                      "version": "0.2.3",
                      "isDefault": true,
                      "description": "Enyo moonstone app",
                      "class": "moonstone",
                      "deps": ["enyoappinfo", "enyoicon"],
                      "files": [{
                          "url": "@PLUGINDIR@/templates/app-moonstone",
                          "symlink": {
                              "enyo": "@PLUGINDIR@/templates/bootplate-moonstone/enyo",
                              "lib": "@PLUGINDIR@/templates/bootplate-moonstone/lib"
                          }
                      }]
                  }
```
- symlink intends to make symbolic links for local directories or files

Enyo-DCO-1.1-Signed-off-by Junil Kim logyourself@gmail.com
